### PR TITLE
Updating maven dependencies to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>7</version>
+        <version>9</version>
     </parent>
 
     <scm>
@@ -30,6 +30,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.version>3.2.5</maven.version>
     </properties>
 
     <developers>
@@ -52,12 +53,12 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.0.3</version>
+            <version>${maven.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.0.3</version>
+            <version>${maven.version}</version>
         </dependency>
         <dependency>
             <groupId>org.sonatype.sisu</groupId>


### PR DESCRIPTION
Hi,

I recently updated my maven to the latest release (3.2.5) and the plan plugin is not compatible with that version. Probably a change in the API.

[ERROR] Failed to execute goal tk.skuro:plan-maven-plugin:1.1:plan (default-cli) on project ...: Execution default-cli of goal tk.skuro:plan-maven-plugin:1.1:plan failed: An API incompatibility was encountered while executing tk.skuro:plan-maven-plugin:1.1:plan: java.lang.NoSuchMethodError: org.apache.maven.execution.MavenSession.getRepositorySession()Lorg/sonatype/aether/RepositorySystemSession;
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>tk.skuro:plan-maven-plugin:1.1
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/C:/Users/dbeland/.m2/repository/tk/skuro/plan-maven-plugin/1.1/plan-maven-plugin-1.1.jar
[ERROR] urls[1] = file:/C:/Users/dbeland/.m2/repository/org/sonatype/aether/aether-util/1.11/aether-util-1.11.jar
[ERROR] urls[2] = file:/C:/Users/dbeland/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar
[ERROR] urls[3] = file:/C:/Users/dbeland/.m2/repository/org/codehaus/plexus/plexus-utils/2.0.6/plexus-utils-2.0.6.jar
[ERROR] urls[4] = file:/C:/Users/dbeland/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar
[ERROR] urls[5] = file:/C:/Users/dbeland/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[6] = file:/C:/Users/dbeland/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[7] = file:/C:/Users/dbeland/.m2/repository/org/sonatype/sisu/sisu-inject-bean/2.1.1/sisu-inject-bean-2.1.1.jar
[ERROR] urls[8] = file:/C:/Users/dbeland/.m2/repository/org/sonatype/sisu/sisu-guice/2.9.4/sisu-guice-2.9.4-no_aop.jar
[ERROR] urls[9] = file:/C:/Users/dbeland/.m2/repository/com/samskivert/jmustache/1.5/jmustache-1.5.jar
[ERROR] Number of foreign imports: 1[

Recompiling the plugin against the latest API fixes the problem, although the 1.2-SNAPSHOT would fail with a similar error when run with maven 3.0.4.

I hope you can make a 1.2 release soon.

Thanks
